### PR TITLE
Create ClusterRoleBinding to sync ClusterRole for the controller

### DIFF
--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -42,6 +42,9 @@ This parameter can be used to configure a ClusterRole (by name) which the sync j
 The ClusterRole must exist on the cluster.
 The component doesn't offer support to deploy an additional ClusterRole.
 
+Additionally, the component creates a `ClusterRoleBinding` to the provided ClusterRole for the statefulset-resize-controller.
+This ensures that the controller can create RoleBindings for the provided ClusterRole.
+
 If the parameter is the empty string, no additional ClusterRole is configured for the sync jobs.
 
 For example, this parameter can be used to allow the sync jobs to use a non-default PodSecurityPolicy, by specifying a ClusterRole which allows using that PodSecurityPolicy.


### PR DESCRIPTION
Otherwise the controller potentially cannot create the RoleBinding to the sync ClusterRole.

Also refactor output generation in component to allow for multiple objects of the same kind.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
